### PR TITLE
Fix docs-loader OTLP exporter crash on insecure endpoint

### DIFF
--- a/docker-compose.all-in-one.yml
+++ b/docker-compose.all-in-one.yml
@@ -100,6 +100,7 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://clickstack:4318
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_INSECURE=true
       - OTEL_SERVICE_NAME=docs-loader
       - OTEL_EXPORTER_OTLP_HEADERS=authorization=${HYPERDX_API_KEY}
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://clickstack:4318
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_INSECURE=true
       - OTEL_SERVICE_NAME=docs-loader
       - OTEL_EXPORTER_OTLP_HEADERS=authorization=${HYPERDX_API_KEY}
     healthcheck:


### PR DESCRIPTION
## Summary
Fixes the `docs-loader` container crash reported in #18:

```
error setting up OTel SDK - failed to create span exporter:
insecure HTTP endpoint cannot use TLS client configuration
```

The OTLP exporter points at a plain-HTTP endpoint (`http://clickstack:4318`), but the launcher applies a TLS client config by default. Recent dependency bumps made the exporter strict, so it now hard-rejects that combination and the container exits at startup. Setting `OTEL_EXPORTER_OTLP_INSECURE=true` tells the exporter to treat the endpoint as insecure and skip the TLS config.

Applied to both `docker-compose.yml` and `docker-compose.all-in-one.yml`.

## Verification
Built `docs-loader` from source and ran with the exact compose env:
- **Without** the flag → crashes immediately with the reported error (exit 1), for both `http/protobuf` and grpc protocols.
- **With** `OTEL_EXPORTER_OTLP_INSECURE=true` → starts cleanly and stays running.

## Note
The pinned `26.4.0-docs-loader` image (built 2026-04-01) predates the dependency bumps and does not exhibit the crash; it should be rebuilt/republished so the `compose up` image path matches the from-source behavior.

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
