### PR TITLE
Add Kubernetes manifests for the demo stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+k8s/secret.env
 **/.DS_Store
 clickhouse/**
 clickstack/**

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,99 @@
+# Kubernetes deployment
+
+A Kubernetes port of the docker-compose stack, as raw manifests wired
+together with [Kustomize](https://kustomize.io/).
+
+Everything runs in the `clickstack-demo` namespace.
+
+## What's here
+
+| File | Resource(s) |
+|------|-------------|
+| `namespace.yaml` | `clickstack-demo` namespace |
+| `clickstack.yaml` | ClickStack OTel collector (OTLP ingest gateway → ClickHouse Cloud) + Service |
+| `postgres.yaml` | Postgres Deployment, Service, PVC, and the `init.sql` ConfigMap |
+| `subscription-app.yaml` | Flask app Deployment + ClusterIP Service (`8000`) |
+| `docs-loader.yaml` | Go docs-loader Deployment + Service |
+| `load-generator.yaml` | Locust load generator Deployment |
+| `otel-collector.yaml` | Infra-metrics collector (kubeletstats + k8s_cluster) with ServiceAccount + RBAC |
+| `kustomization.yaml` | Ties it together + generates the `clickstack-secrets` Secret |
+
+### Differences from docker-compose
+
+- **Infra metrics:** docker-compose used `socat` + the `docker_stats`
+  receiver to read the Docker socket. Kubernetes has no Docker socket, so the
+  `otel-collector` here uses the K8s-native **`kubeletstats`** and
+  **`k8s_cluster`** receivers instead (with a ServiceAccount + ClusterRole).
+  The `socat` service is gone.
+- The subscription app is reached via `kubectl port-forward` rather than a
+  published host port.
+- Credentials come from a Kustomize-generated Secret (`k8s/secret.env`) instead
+  of the repo-root `.env`. This keeps `k8s/` self-contained — kustomize cannot
+  read files above its own directory, so pointing at `../.env` would force
+  `--load-restrictor LoadRestrictionsNone` onto every command. It's the same
+  four keys, so `cp ../.env secret.env` works if you already ran compose.
+
+## Quick Start
+
+1. **Create a ClickHouse Cloud service**
+    - https://console.clickhouse.cloud
+
+2. **Clone the repo**
+   ```bash
+   git clone https://github.com/ClickHouse/clickstack-demo-subscription-app
+   ```
+
+3. **Access the k8s directory**
+   ```bash
+   cd clickstack-demo-subscription-app/k8s
+   ```
+
+4. **Create a secret.env file**
+   ```bash
+   CLICKHOUSE_ENDPOINT=<HOST-WITH-PORT>
+   CLICKHOUSE_USER=default
+   CLICKHOUSE_PASSWORD=<PASSWORD>
+   HYPERDX_API_KEY=<INGESTION-PASSWORD>
+   ```
+
+5. **Edit secret.env with the connection information to your service**
+
+6. **Edit secret.env with your own HyperDX API key to securely ingest data**
+
+7. **Start all services**
+   ```bash
+   kubectl apply -k .
+   ```
+
+8. **(Optional) Port forward the frontend service**
+   ```bash
+   kubectl -n clickstack-demo port-forward svc/subscription-app 8000:8000
+   ```
+
+9. **(Optional) Access the subscription app in your browser**
+    - http://localhost:8000
+
+## Remove resources
+
+```bash
+kubectl delete -k .
+```
+
+This also removes the namespace, the PVC (and thus the Postgres data), and the
+generated Secret. The `clickstack-demo-otel-collector`
+ClusterRole/ClusterRoleBinding are cluster-scoped and are removed by
+`delete -k` as well.
+
+## Common tweaks
+
+- **More/less load:** edit `LOCUST_USERS` in `load-generator.yaml`.
+- **Use a different local port:** change the left-hand side of the
+  port-forward, e.g. `port-forward svc/subscription-app 9000:8000`.
+- **Rotate credentials:** edit `secret.env`, re-run `kubectl apply -k .`, then
+  restart the pods so they pick up the new values (the Secret name is stable, so
+  an updated Secret alone won't restart anything):
+
+  ```bash
+  kubectl apply -k .
+  kubectl -n clickstack-demo rollout restart deployment
+  ```

--- a/k8s/clickstack.yaml
+++ b/k8s/clickstack.yaml
@@ -1,0 +1,70 @@
+# ClickStack OTel collector: the ingestion gateway. Apps and the
+# infra otel-collector send OTLP here; it forwards to ClickHouse Cloud.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickstack
+  labels:
+    app: clickstack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickstack
+  template:
+    metadata:
+      labels:
+        app: clickstack
+    spec:
+      containers:
+        - name: clickstack
+          image: clickhouse/clickstack-otel-collector:2.19.0
+          ports:
+            - { name: otlp-grpc, containerPort: 4317 }
+            - { name: otlp-http, containerPort: 4318 }
+            - { name: health, containerPort: 13133 }
+          env:
+            - name: OTLP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: clickstack-secrets
+                  key: HYPERDX_API_KEY
+            - name: CLICKHOUSE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: clickstack-secrets
+                  key: CLICKHOUSE_ENDPOINT
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: clickstack-secrets
+                  key: CLICKHOUSE_USER
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: clickstack-secrets
+                  key: CLICKHOUSE_PASSWORD
+          readinessProbe:
+            tcpSocket: { port: 13133 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket: { port: 13133 }
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits: { cpu: "1", memory: 1Gi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickstack
+  labels:
+    app: clickstack
+spec:
+  selector:
+    app: clickstack
+  ports:
+    - { name: otlp-grpc, port: 4317, targetPort: 4317 }
+    - { name: otlp-http, port: 4318, targetPort: 4318 }

--- a/k8s/docs-loader.yaml
+++ b/k8s/docs-loader.yaml
@@ -1,0 +1,60 @@
+# Go "docs loader" helper service called by the subscription app.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docs-loader
+  labels:
+    app: docs-loader
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: docs-loader
+  template:
+    metadata:
+      labels:
+        app: docs-loader
+    spec:
+      containers:
+        - name: docs-loader
+          image: ghcr.io/clickhouse/clickstack-demo-subscription-app:26.4.0-docs-loader
+          ports:
+            - { name: http, containerPort: 8001 }
+          env:
+            - { name: PORT, value: "8001" }
+            - { name: OTEL_EXPORTER_OTLP_ENDPOINT, value: http://clickstack:4318 }
+            - { name: OTEL_EXPORTER_OTLP_PROTOCOL, value: http/protobuf }
+            # The endpoint is plain http, so the exporter must be told it is
+            # insecure or it applies a TLS client config and crashes at startup.
+            - { name: OTEL_EXPORTER_OTLP_INSECURE, value: "true" }
+            - { name: OTEL_SERVICE_NAME, value: docs-loader }
+            # HDX_KEY must be declared before the var that interpolates it.
+            - name: HDX_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: clickstack-secrets
+                  key: HYPERDX_API_KEY
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              value: authorization=$(HDX_KEY)
+          readinessProbe:
+            httpGet: { path: /, port: 8001 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # The tight memory limit is deliberate and matches docker-compose:
+          # GET /load grows memory in the request handler and never responds,
+          # so the container gets OOM-killed. That OOM *is* the demo.
+          resources:
+            requests: { cpu: 10m, memory: 10M }
+            limits: { cpu: 200m, memory: 10M }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docs-loader
+  labels:
+    app: docs-loader
+spec:
+  selector:
+    app: docs-loader
+  ports:
+    - { name: http, port: 8001, targetPort: 8001 }

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Everything lands in this namespace (cluster-scoped objects like the
+# otel-collector ClusterRole/Binding are left cluster-scoped automatically).
+namespace: clickstack-demo
+
+resources:
+  - namespace.yaml
+  - clickstack.yaml
+  - postgres.yaml
+  - docs-loader.yaml
+  - subscription-app.yaml
+  - load-generator.yaml
+  - otel-collector.yaml
+
+# Secrets are generated from a local, git-ignored env file so credentials
+# never live in a committed manifest. Create secret.env with your ClickHouse
+# Cloud / HyperDX values before applying -- see README.md ("Quick Start").
+#
+# This keeps k8s/ self-contained: kustomize cannot read files above its own
+# directory, so reusing the repo-root `.env` would force every command to carry
+# `--load-restrictor LoadRestrictionsNone`. The values are the same four keys,
+# so `cp ../.env secret.env` is a valid shortcut if you already ran compose.
+secretGenerator:
+  - name: clickstack-secrets
+    envs:
+      - secret.env
+
+# Stable resource names (no content-hash suffix) so this is easy to read,
+# kubectl get, and reason about in a demo.
+generatorOptions:
+  disableNameSuffixHash: true
+
+# includeSelectors keeps this label in Deployment selectors too (what the
+# older `commonLabels` field did), so the rendered output is unchanged.
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/part-of: clickstack-demo

--- a/k8s/load-generator.yaml
+++ b/k8s/load-generator.yaml
@@ -1,0 +1,35 @@
+# Locust load generator that continuously drives the subscription app,
+# producing traffic (and telemetry) for the demo. No Service needed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: load-generator
+  labels:
+    app: load-generator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: load-generator
+  template:
+    metadata:
+      labels:
+        app: load-generator
+    spec:
+      containers:
+        - name: load-generator
+          image: ghcr.io/clickhouse/clickstack-demo-subscription-app:26.4.0-load-generator
+          env:
+            - { name: LOCUST_WEB_PORT, value: "8081" }
+            - { name: LOCUST_USERS, value: "5" }
+            - { name: LOCUST_HOST, value: http://subscription-app:8000 }
+            - { name: LOCUST_HEADLESS, value: "true" }
+            - { name: LOCUST_AUTOSTART, value: "true" }
+            - { name: LOCUST_WEB_HOST, value: 0.0.0.0 }
+          # Deliberately no limits, matching docker-compose (which sets none for
+          # this service). Each of the LOCUST_USERS drives a real Chromium via
+          # locust-plugins' PlaywrightUser, so memory use is far higher than a
+          # plain HTTP load generator -- a 1Gi cap here got the pod OOMKilled in
+          # a restart loop. The request is just a scheduling hint.
+          resources:
+            requests: { cpu: 200m, memory: 512Mi }

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickstack-demo
+  labels:
+    app.kubernetes.io/part-of: clickstack-demo

--- a/k8s/otel-collector.yaml
+++ b/k8s/otel-collector.yaml
@@ -1,0 +1,160 @@
+# Infra metrics collector. In docker-compose this scraped the Docker socket
+# (via socat) with the docker_stats receiver. Kubernetes has no Docker
+# socket, so we use the K8s-native kubeletstats + k8s_cluster receivers
+# instead. Both ship in the otel-collector-contrib distro this image is
+# built from.
+#
+# NOTE: kubeletstats here scrapes only the node this pod runs on. That's
+# fine for a single-node demo cluster (kind/minikube/Docker Desktop). For a
+# multi-node cluster, split this into a DaemonSet (kubeletstats, one per
+# node) plus a single-replica Deployment (k8s_cluster).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  labels:
+    app: otel-collector
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clickstack-demo-otel-collector
+  labels:
+    app: otel-collector
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/stats
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - namespaces
+      - services
+      - endpoints
+      - events
+      - replicationcontrollers
+      - resourcequotas
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clickstack-demo-otel-collector
+  labels:
+    app: otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clickstack-demo-otel-collector
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector
+    # namespace is set by kustomize (clickstack-demo)
+    namespace: clickstack-demo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  labels:
+    app: otel-collector
+data:
+  config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    receivers:
+      kubeletstats:
+        collection_interval: 15s
+        auth_type: serviceAccount
+        endpoint: https://${env:K8S_NODE_NAME}:10250
+        insecure_skip_verify: true
+        metric_groups:
+          - node
+          - pod
+          - container
+      k8s_cluster:
+        collection_interval: 15s
+
+    exporters:
+      otlp/hdx:
+        endpoint: 'clickstack:4317'
+        headers:
+          authorization: ${env:HYPERDX_API_KEY}
+        tls:
+          insecure: true
+      debug:
+        verbosity: basic
+
+    processors:
+      batch:
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [kubeletstats, k8s_cluster]
+          processors: [batch]
+          exporters: [otlp/hdx]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  labels:
+    app: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      serviceAccountName: otel-collector
+      containers:
+        - name: otel-collector
+          image: ghcr.io/clickhouse/clickstack-demo-subscription-app:26.4.0-otel-collector
+          ports:
+            - { name: health, containerPort: 13133 }
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HYPERDX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: clickstack-secrets
+                  key: HYPERDX_API_KEY
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol-contrib
+          readinessProbe:
+            httpGet: { path: /, port: 13133 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /, port: 13133 }
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,96 @@
+# Postgres backing store for the subscription app.
+# init.sql is mounted from a ConfigMap into the image's initdb hook dir,
+# matching the docker-compose bind mount.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+  labels:
+    app: postgres-db
+data:
+  init.sql: |
+    CREATE TABLE IF NOT EXISTS users (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(255),
+        company VARCHAR(255),
+        email VARCHAR(255),
+        source VARCHAR(255),
+        submitted_at TIMESTAMP DEFAULT now()
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS unique_email_index ON users (email);
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  labels:
+    app: postgres-db
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-db
+  labels:
+    app: postgres-db
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate # single RWO volume; don't run two pods against it
+  selector:
+    matchLabels:
+      app: postgres-db
+  template:
+    metadata:
+      labels:
+        app: postgres-db
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:18.3
+          ports:
+            - { name: postgres, containerPort: 5432 }
+          env:
+            - { name: POSTGRES_DB, value: postgres }
+            - { name: POSTGRES_PASSWORD, value: changeme }
+            # Keep PGDATA in a subdir so the volume root can be the mount
+            # point (mirrors the compose mount at /var/lib/postgresql).
+            - { name: PGDATA, value: /var/lib/postgresql/data/pgdata }
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/postgresql }
+            - { name: init, mountPath: /docker-entrypoint-initdb.d }
+          readinessProbe:
+            exec: { command: ["pg_isready", "-U", "postgres"] }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            exec: { command: ["pg_isready", "-U", "postgres"] }
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data
+        - name: init
+          configMap:
+            name: postgres-init
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-db
+  labels:
+    app: postgres-db
+spec:
+  selector:
+    app: postgres-db
+  ports:
+    - { name: postgres, port: 5432, targetPort: 5432 }

--- a/k8s/subscription-app.yaml
+++ b/k8s/subscription-app.yaml
@@ -1,0 +1,78 @@
+# The Flask subscription app (frontend + backend), fully OTel-instrumented.
+# A plain ClusterIP Service: the load-generator reaches it in-cluster at
+# http://subscription-app:8000, and you reach it from the host with
+# `kubectl port-forward` (see README). Deliberately not a NodePort -- on kind
+# node ports aren't published to the host unless the cluster was created with
+# extraPortMappings, so a NodePort URL would just hang there.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: subscription-app
+  labels:
+    app: subscription-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: subscription-app
+  template:
+    metadata:
+      labels:
+        app: subscription-app
+    spec:
+      containers:
+        - name: subscription-app
+          image: ghcr.io/clickhouse/clickstack-demo-subscription-app:26.4.0-subscription-app
+          ports:
+            - { name: http, containerPort: 8000 }
+          env:
+            # PostgreSQL
+            - { name: POSTGRES_HOST, value: postgres-db }
+            - { name: POSTGRES_PORT, value: "5432" }
+            - { name: POSTGRES_USERNAME, value: postgres }
+            - { name: POSTGRES_PASSWORD, value: changeme }
+            - { name: POSTGRES_DATABASE, value: postgres }
+            # HyperDX / OTel
+            - name: HYPERDX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: clickstack-secrets
+                  key: HYPERDX_API_KEY
+            - { name: OTEL_SERVICE_NAME, value: subscription-backend }
+            - { name: OTEL_EXPORTER_OTLP_ENDPOINT, value: http://clickstack:4318 }
+            - { name: HYPERDX_ENABLE_ADVANCED_NETWORK_CAPTURE, value: "1" }
+            - { name: HYPERDX_SERVICE_NAME, value: subscription-frontend }
+            - { name: HYPERDX_ENDPOINT, value: http://clickstack:4318 }
+            # Docs loader
+            - { name: DOCS_LOADER_HOST, value: docs-loader }
+            - { name: DOCS_LOADER_PORT, value: "8001" }
+            # Flask
+            - { name: FLASK_HOST, value: 0.0.0.0 }
+            - { name: FLASK_PORT, value: "8000" }
+            - { name: FLASK_DEBUG, value: "false" }
+            # Logging
+            - { name: LOG_LEVEL, value: INFO }
+          readinessProbe:
+            httpGet: { path: /health, port: 8000 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: 8000 }
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: subscription-app
+  labels:
+    app: subscription-app
+spec:
+  type: ClusterIP
+  selector:
+    app: subscription-app
+  ports:
+    - { name: http, port: 8000, targetPort: 8000 }


### PR DESCRIPTION
## What

A Kustomize-based port of the docker-compose stack to Kubernetes, in the `clickstack-demo` namespace. Apply with `kubectl apply -k .` from `k8s/`.

## Verified

Deployed end-to-end on a `kind` cluster (k8s v1.36.1). All six deployments reached Available; ClickHouse Cloud received, in a 4-minute window:

- **2,787 trace rows** from `subscription-frontend`, `subscription-backend`, and `docs-loader`
- **360 log rows**
- **6,828 gauge rows**, including **37 distinct `k8s.*` metrics** and 10 `container.*` metrics, with correct per-pod attribution

No RBAC/`forbidden` errors and no exporter failures. App reachable from the host via `port-forward` (`HTTP 200`), and the docs-loader OOM demo reproduces correctly (request hangs ~11s, then `OOMKilled` exit 137).

## Differences from docker-compose, and why

- **Infra metrics:** compose read the Docker socket via `socat` + the `docker_stats` receiver. Kubernetes has no Docker socket, so `otel-collector` uses the K8s-native **`kubeletstats`** + **`k8s_cluster`** receivers with a ServiceAccount + ClusterRole. The `socat` service is gone.
- **Access:** `subscription-app` is a `ClusterIP` Service reached with `kubectl port-forward`. A NodePort was deliberately avoided — on `kind`, the most common local choice, node ports aren't published to the host unless the cluster was created with `extraPortMappings`, so a NodePort would hand out a URL that silently hangs.
- **Credentials:** a git-ignored `k8s/secret.env` via `secretGenerator`, keeping `k8s/` self-contained. Kustomize can't read files above its own directory, so reusing the repo-root `.env` would force `--load-restrictor LoadRestrictionsNone` onto every command.

## Two settings that are load-bearing

Please don't "clean these up" — both are deliberate:

- **`docs-loader` sets `OTEL_EXPORTER_OTLP_INSECURE=true`.** Its OTLP endpoint is plain http; without this the exporter applies a TLS client config and crashes at startup. Same fix as 8f3fea5 (#18), which landed in the compose files only — so this bug was still live in the k8s port.
- **`docs-loader` is capped at `10M` memory**, matching compose. `GET /load` grows memory in the request handler and never responds, so the container is OOM-killed. That OOM *is* the demo.

`load-generator` intentionally has **no** memory limit, as in compose. It drives real Chromium instances via locust-plugins' `PlaywrightUser`; an earlier 1Gi cap put the pod in an `OOMKilled` restart loop.

## Note

`k8s/secret.env` is git-ignored and not included. Create it from the four keys in the README's Quick Start (or `cp ../.env secret.env` if you've already run compose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
